### PR TITLE
Add Python course TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Codex Coming Soon Page
+# Codex Python Course Preview
 
-This repository contains a simple HTML page that displays a "Content Coming Soon" message. Open `index.html` in your browser to view it.
+This repository now displays a preview of an upcoming Python course. Open `index.html` in your browser to see a table of contents covering topics from basic syntax to machine learning.

--- a/index.html
+++ b/index.html
@@ -3,23 +3,56 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Coming Soon</title>
+    <title>Python Course Coming Soon</title>
     <style>
         body {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-            margin: 0;
             font-family: Arial, sans-serif;
             background-color: #f4f4f4;
+            margin: 0;
+            padding: 40px;
         }
         h1 {
+            text-align: center;
             color: #333;
+        }
+        ul {
+            max-width: 600px;
+            margin: 20px auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        li {
+            margin: 8px 0;
         }
     </style>
 </head>
 <body>
-    <h1>Content Coming Soon</h1>
+    <h1>Python Course &mdash; Coming Soon</h1>
+    <ul>
+        <li>Introduction to Python</li>
+        <li>Setting Up Your Environment</li>
+        <li>Basic Syntax and Variables</li>
+        <li>Data Types and Operators</li>
+        <li>Control Flow</li>
+        <li>Loops</li>
+        <li>Functions</li>
+        <li>Modules and Packages</li>
+        <li>File Handling</li>
+        <li>Error Handling</li>
+        <li>Object-Oriented Programming</li>
+        <li>Standard Library Overview</li>
+        <li>Virtual Environments and Package Management</li>
+        <li>Testing and Debugging</li>
+        <li>Working with Data (JSON, CSV)</li>
+        <li>Web Scraping</li>
+        <li>Introduction to Web Frameworks (Flask/Django)</li>
+        <li>Databases with Python</li>
+        <li>Working with APIs</li>
+        <li>Intro to Data Analysis with pandas</li>
+        <li>Basics of Machine Learning with scikit-learn</li>
+        <li>Best Practices and Next Steps</li>
+    </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- showcase a Python course preview
- list upcoming Python course modules

## Testing
- `docker -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451b9bc2008320aa4147b10256818b