### PR TITLE
Update index for finance analyst focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Codex Python Course Preview
+# Codex Python for Finance Analysts Preview
 
-This repository now displays a preview of an upcoming Python course. Open `index.html` in your browser to see a table of contents covering topics from basic syntax to machine learning.
+This repository displays a preview of an upcoming Python course focused on finance applications. Open `index.html` in your browser to see a finance-tailored table of contents.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Python Course Coming Soon</title>
+    <title>Python for Finance Analysts Coming Soon</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -29,29 +29,27 @@
     </style>
 </head>
 <body>
-    <h1>Python Course &mdash; Coming Soon</h1>
+    <h1>Python for Finance Analysts &mdash; Coming Soon</h1>
     <ul>
-        <li>Introduction to Python</li>
-        <li>Setting Up Your Environment</li>
-        <li>Basic Syntax and Variables</li>
-        <li>Data Types and Operators</li>
-        <li>Control Flow</li>
-        <li>Loops</li>
-        <li>Functions</li>
-        <li>Modules and Packages</li>
-        <li>File Handling</li>
-        <li>Error Handling</li>
-        <li>Object-Oriented Programming</li>
-        <li>Standard Library Overview</li>
-        <li>Virtual Environments and Package Management</li>
-        <li>Testing and Debugging</li>
-        <li>Working with Data (JSON, CSV)</li>
-        <li>Web Scraping</li>
-        <li>Introduction to Web Frameworks (Flask/Django)</li>
-        <li>Databases with Python</li>
-        <li>Working with APIs</li>
-        <li>Intro to Data Analysis with pandas</li>
-        <li>Basics of Machine Learning with scikit-learn</li>
+        <li>Course Overview: Python for Finance</li>
+        <li>Setting Up Your Finance Environment</li>
+        <li>Python Fundamentals for Finance</li>
+        <li>Data Structures, Control Flow, and Functions</li>
+        <li>Modules, Packages, and Virtual Environments</li>
+        <li>Working with pandas and NumPy</li>
+        <li>Importing Financial Data (APIs and Spreadsheets)</li>
+        <li>Time Series Analysis</li>
+        <li>Data Visualization for Markets</li>
+        <li>Risk and Return Calculations</li>
+        <li>Portfolio Optimization</li>
+        <li>Automating Financial Reports</li>
+        <li>Database Integration</li>
+        <li>Introduction to Quantitative Models</li>
+        <li>Machine Learning for Trading Strategies</li>
+        <li>Building Dashboards with Streamlit</li>
+        <li>Working with Web APIs</li>
+        <li>Testing and Debugging Finance Scripts</li>
+        <li>Project: Market Data Analysis</li>
         <li>Best Practices and Next Steps</li>
     </ul>
 </body>


### PR DESCRIPTION
## Summary
- change heading to "Python for Finance Analysts"
- replace table of contents with finance analyst topics
- update README description

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451c9a5df08320b8c0bd71b0694904